### PR TITLE
TEAM01-23 Add PUT endpoint for Recommendation Request

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -93,4 +93,26 @@ public class RecommendationRequestController extends ApiController {
 
         return savedRecommendationRequest;
     }
+
+    @Operation(summary= "Update a single date")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public RecommendationRequest updateRecommendationRequest(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid RecommendationRequest incoming) {
+
+        RecommendationRequest request = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        request.setRequesterEmail(incoming.getRequesterEmail());
+        request.setProfessorEmail(incoming.getProfessorEmail());
+        request.setExplanation(incoming.getExplanation());
+        request.setDateRequested(incoming.getDateRequested());
+        request.setDateNeeded(incoming.getDateNeeded());
+        request.setDone(incoming.getDone());
+
+        recommendationRequestRepository.save(request);
+
+        return request;
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -284,10 +284,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
             verify(recommendationRequestRepository, times(1)).findById(67L);
             Map<String, Object> json = responseToJson(response);
             assertEquals("RecommendationRequest with id 67 not found", json.get("message"));
-
     }
-
-
 
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -2,9 +2,13 @@ package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.RecommendationRequest;
 import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
 import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
 
@@ -18,8 +22,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -197,6 +205,89 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
             String responseString = response.getResponse().getContentAsString();
             assertEquals(expectedJson, responseString);
     }
+
+    // Test for PUT /api/recommendationrequests/
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_edit_an_existing_recommendationrequest() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+            LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+            RecommendationRequest requestOrig = RecommendationRequest.builder()
+                            .requesterEmail("testRequesterEmail")
+                            .professorEmail("testProfessorEmail")
+                            .explanation("testExplanation")
+                            .dateRequested(ldt1)
+                            .dateNeeded(ldt1)
+                            .done(false)
+                            .build();
+
+            RecommendationRequest requestEdited = RecommendationRequest.builder()
+                            .requesterEmail("testRequesterEmail1")
+                            .professorEmail("testProfessorEmail1")
+                            .explanation("testExplanation1")
+                            .dateRequested(ldt2)
+                            .dateNeeded(ldt2)
+                            .done(true)
+                            .build();
+
+            String requestBody = mapper.writeValueAsString(requestEdited);
+
+            when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(requestOrig));
+
+            MvcResult response = mockMvc.perform(
+                            put("/api/recommendationrequests?id=67")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            verify(recommendationRequestRepository, times(1)).findById(67L);
+            verify(recommendationRequestRepository, times(1)).save(requestEdited); // should be saved with correct user
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(requestBody, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            RecommendationRequest requestEdited = RecommendationRequest.builder()
+                            .requesterEmail("testRequesterEmailEdited")
+                            .professorEmail("testProfessorEmailEdited")
+                            .explanation("testExplanationEdited")
+                            .dateRequested(ldt1)
+                            .dateNeeded(ldt1)
+                            .done(true)
+                            .build();
+
+            String requestBody = mapper.writeValueAsString(requestEdited);
+
+            when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/recommendationrequests?id=67")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(recommendationRequestRepository, times(1)).findById(67L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("RecommendationRequest with id 67 not found", json.get("message"));
+
+    }
+
+
 
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test


### PR DESCRIPTION
This new endpoint always admin users to find an element by id and edit its contents by passing a json file. This is essential for editing the contents of the table. Closes #23.