### PR TITLE
TEAM01-24 Add Delete Endpoint to Recommendation Request Table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -56,6 +56,18 @@ public class RecommendationRequestController extends ApiController {
         return request;
     }
 
+    @Operation(summary= "Delete a RecommendationRequest")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteRecommendationRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        RecommendationRequest request = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        recommendationRequestRepository.delete(request);
+        return genericMessage("RecommendationRequest with id %s deleted".formatted(id));
+    }
+
     @Operation(summary= "Create a new request")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -197,4 +197,56 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
             String responseString = response.getResponse().getContentAsString();
             assertEquals(expectedJson, responseString);
     }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_recommendationrequest() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            RecommendationRequest request1 = RecommendationRequest.builder()
+                            .requesterEmail("testRequesterEmail1")
+                            .professorEmail("testProfessorEmail1")
+                            .explanation("testExplanation1")
+                            .dateRequested(ldt1)
+                            .dateNeeded(ldt1)
+                            .done(false)
+                            .build();
+
+            when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.of(request1));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/recommendationrequests?id=15")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(recommendationRequestRepository, times(1)).findById(15L);
+            verify(recommendationRequestRepository, times(1)).delete(any());
+
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("RecommendationRequest with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_recommendationrequest_and_gets_right_error_message()
+                    throws Exception {
+            // arrange
+
+            when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/recommendationrequests?id=15")
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(recommendationRequestRepository, times(1)).findById(15L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("RecommendationRequest with id 15 not found", json.get("message"));
+    }
 }


### PR DESCRIPTION
Users can lookup elements by id and remove them from the database. Closes #24.